### PR TITLE
Minor fixes

### DIFF
--- a/japanese_address/__init__.py
+++ b/japanese_address/__init__.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
 import logging
 
-from pkg_resources import resource_stream
-
 from parsel import Selector
-
+from pkg_resources import resource_stream
 
 __version__ = '0.1.2'
 
@@ -23,19 +21,20 @@ KANJI = {
 }
 
 
-def load_wiki(datafile, endchar):
+def load_wiki(datafile, column, endchar):
     sel = Selector(text=resource_stream('japanese_address', datafile).read().decode('utf8'))
-    for trow in sel.xpath('//tr'):
+    rows = sel.xpath(f'//th[contains(.,"{column}")]/ancestor::table//tr[not(th)]')
+    for trow in rows:
         japtext = trow.xpath('.//*[@lang="ja"]/text()').extract()
         if japtext and japtext[0].endswith(endchar):
-            engtext = trow.xpath('.//*[@lang="ja"]/ancestor::td/preceding-sibling::td//text()').extract()[-1]
+            engtext = trow.xpath('.//*[@lang="ja"]/ancestor::td/preceding-sibling::td//text()').get()
             if engtext:
                 yield japtext[0], engtext
 
 
-TOWNS_DATA = dict(load_wiki('data/towns.html', KANJI["town"]))
-CITIES_DATA = dict(load_wiki('data/cities.html', KANJI["city"]))
-WARDS_DATA = dict(load_wiki('data/wards.html', KANJI["ward"]))
+TOWNS_DATA = dict(load_wiki('data/towns.html', 'Town', KANJI["town"]))
+CITIES_DATA = dict(load_wiki('data/cities.html', 'City', KANJI["city"]))
+WARDS_DATA = dict(load_wiki('data/wards.html', 'Ward', KANJI["ward"]))
 
 
 def _parse_prefecture(txt):

--- a/japanese_address/__init__.py
+++ b/japanese_address/__init__.py
@@ -14,6 +14,13 @@ logger = logging.getLogger(__name__)
 
 PREFECTURES_DATA = dict([l.decode('utf8').split() for l in resource_stream('japanese_address', 'data/prefs.dat')])
 JAPANESE_PREFECTURES = list(PREFECTURES_DATA.keys())
+KANJI = {
+    "city": "市",
+    "ward": "区",
+    "district": "郡",
+    "town": "町",
+    "city_district": "丁目",
+}
 
 
 def load_wiki(datafile, endchar):
@@ -26,9 +33,9 @@ def load_wiki(datafile, endchar):
                 yield japtext[0], engtext
 
 
-CITIES_DATA = dict(load_wiki('data/cities.html', "市"))
-WARDS_DATA = dict(load_wiki('data/wards.html', "区"))
-TOWNS_DATA = dict(load_wiki('data/towns.html', "町"))
+TOWNS_DATA = dict(load_wiki('data/towns.html', KANJI["town"]))
+CITIES_DATA = dict(load_wiki('data/cities.html', KANJI["city"]))
+WARDS_DATA = dict(load_wiki('data/wards.html', KANJI["ward"]))
 
 
 def _parse_prefecture(txt):
@@ -76,19 +83,19 @@ def parse(txt):
     else:
         parsed['unparsed_right'] = txt
 
-    _parse_level('city', "市", parsed)
+    _parse_level('city', KANJI["city"], parsed)
     if 'city' in parsed:
         parsed['city_eng'] = CITIES_DATA[parsed['city']]
-    _parse_level('ward', "区", parsed)
+    _parse_level('ward', KANJI["ward"], parsed)
     if 'ward' in parsed:
         parsed['ward_eng'] = WARDS_DATA[parsed['ward']]
-    _parse_level('district', "郡", parsed)
-    _parse_level('town', "町", parsed)
+    _parse_level('district', KANJI["district"], parsed)
+    _parse_level('town', KANJI["town"], parsed)
     if 'town' in parsed:
         if parsed['town'] in TOWNS_DATA:
             parsed['town_eng'] = TOWNS_DATA[parsed['town']]
         else:
             logger.warning(f"Town {parsed['town']} not in database")
-    _parse_level('city_district', "丁目", parsed)
+    _parse_level('city_district', KANJI["city_district"], parsed)
 
     return parsed

--- a/japanese_address/__init__.py
+++ b/japanese_address/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
+import re
 
 from parsel import Selector
 from pkg_resources import resource_stream
@@ -45,9 +46,12 @@ def _parse_prefecture(txt):
 
 
 def _parse_divisor(txt, divisor, dlen):
-    start = txt.find(divisor)
-    if start >= 0:
-        return txt[0:start+dlen].strip()
+    # search for the divisor, skiping the first one (eg. 市川市  => Ichikawa)
+    # until the last ocurrence of the divisor (eg. 野々市市 => Nonoichi)
+    match = re.search(f'^.+?{divisor}+', txt)
+    if match:
+        # return the municipality name, without the divisor
+        return match.group()
 
 
 def _parse_level(div, kanji, parsed):


### PR DESCRIPTION
- Update `load_wiki()` (it was missing some locations)
- Handle cases where the locations names have more than one ocurrence of the kanji used as suffix
  - eg. 市川市  (Ichikawa-shi)
- Move all kanji into a single dict