### PR TITLE
Fix _parse_prefecture to support the texts that don't start with prefecture

### DIFF
--- a/japanese_address/__init__.py
+++ b/japanese_address/__init__.py
@@ -72,6 +72,7 @@ def parse(txt):
     """
     >>> parse('北海道 札幌市 中央区北5条西4-7')
     >>> parse('東京都江東区豊洲2丁目4-9')
+    >>> parse("〒600-8216 京都府京都市下京区烏丸通七条下ル 東塩小路町 721-1")
     """
     parsed = {}
     pref = _parse_prefecture(txt)

--- a/japanese_address/__init__.py
+++ b/japanese_address/__init__.py
@@ -42,7 +42,7 @@ def _parse_prefecture(txt):
     for pref in JAPANESE_PREFECTURES:
         start = txt.find(pref)
         if start >= 0:
-            return txt[start:len(pref)].strip()
+            return txt[start : start + len(pref)]
 
 
 def _parse_divisor(txt, divisor, dlen):


### PR DESCRIPTION
Before:

```python
>>> parse("〒600-8216 京都府京都市下京区烏丸通七条下ル 東塩小路町 721-1")
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
<ipython-input-2-f8918f2b25cd> in <module>
----> 1 parse("〒600-8216 京都府京都市下京区烏丸通七条下ル 東塩小路町 721-1")

~/.pyenv/versions/3.7.4/lib/python3.7/site-packages/japanese_address/__init__.py in parse(txt)
     89     _parse_level('city', KANJI["city"], parsed)
     90     if 'city' in parsed:
---> 91         parsed['city_eng'] = CITIES_DATA[parsed['city']]
     92     _parse_level('ward', KANJI["ward"], parsed)
     93     if 'ward' in parsed:

KeyError: '〒600-8216 京都府京都市'
```

That's because `_parse_prefecture()` returned an empty str because of the bug.

After:

```python
>>> parse("〒600-8216 京都府京都市下京区烏丸通七条下ル 東塩小路町 721-1")
Town 烏丸通七条下ル 東塩小路町 not in database
Out[2]:
{'prefecture': '京都府',
 'prefecture_eng': 'Kyoto',
 'unparsed_left': '〒600-8216',
 'unparsed_right': '721-1',
 'city': '京都市',
 'city_eng': 'Kyoto',
 'ward': '下京区',
 'ward_eng': 'Shimogyō',
 'town': '烏丸通七条下ル 東塩小路町'}
```